### PR TITLE
Fix logout user clearing

### DIFF
--- a/lib/features/goals/view/dashboard_screen.dart
+++ b/lib/features/goals/view/dashboard_screen.dart
@@ -25,7 +25,8 @@ class DashboardScreen extends ConsumerWidget {
             onPressed: () async {
               // Googleサインアウト処理
               await AuthService().signOut();
-              ref.read(userStateProvider.notifier).setUser(user);
+              // Clear the logged-in user after signing out
+              ref.read(userStateProvider.notifier).setUser(null);
               final viewModel = ref.read(loginViewModelProvider.notifier);
               viewModel.resetLoginState();
 


### PR DESCRIPTION
## Summary
- clear user provider when logging out from dashboard

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413c45a310832384197336b53f7e6e