### PR TITLE
Unify Riverpod usage with annotations

### DIFF
--- a/lib/features/auth/provider/login_provider.dart
+++ b/lib/features/auth/provider/login_provider.dart
@@ -1,0 +1,11 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'login_provider.g.dart';
+
+@riverpod
+class IsPasswordVisible extends _$IsPasswordVisible {
+  @override
+  bool build() => false;
+
+  void toggle() => state = !state;
+}

--- a/lib/features/auth/provider/login_provider.g.dart
+++ b/lib/features/auth/provider/login_provider.g.dart
@@ -1,27 +1,27 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'login_view_model.dart';
+part of 'login_provider.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$loginViewModelHash() => r'1e2419463a40253fd07e72a9f76f9570f2e9cb2a';
+String _$isPasswordVisibleHash() => r'07ba2d146bd22188fd6b5cf24ad8ba279d6157d4';
 
-/// See also [LoginViewModel].
-@ProviderFor(LoginViewModel)
-final loginViewModelProvider =
-    AutoDisposeNotifierProvider<LoginViewModel, AsyncValue<void>>.internal(
-      LoginViewModel.new,
-      name: r'loginViewModelProvider',
+/// See also [IsPasswordVisible].
+@ProviderFor(IsPasswordVisible)
+final isPasswordVisibleProvider =
+    AutoDisposeNotifierProvider<IsPasswordVisible, bool>.internal(
+      IsPasswordVisible.new,
+      name: r'isPasswordVisibleProvider',
       debugGetCreateSourceHash:
           const bool.fromEnvironment('dart.vm.product')
               ? null
-              : _$loginViewModelHash,
+              : _$isPasswordVisibleHash,
       dependencies: null,
       allTransitiveDependencies: null,
     );
 
-typedef _$LoginViewModel = AutoDisposeNotifier<AsyncValue<void>>;
+typedef _$IsPasswordVisible = AutoDisposeNotifier<bool>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/auth/service/auth_service.dart
+++ b/lib/features/auth/service/auth_service.dart
@@ -1,13 +1,18 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:logger/logger.dart';
 
+
 import '../provider/auth_provider.dart';
 
-final authServiceProvider = Provider<AuthService>((ref) => AuthService());
+part 'auth_service.g.dart';
+
+@riverpod
+AuthService authService(AuthServiceRef ref) => AuthService();
 
 class AuthService {
   // FirebaseAuthインスタンスを取得

--- a/lib/features/auth/service/auth_service.g.dart
+++ b/lib/features/auth/service/auth_service.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auth_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$authServiceHash() => r'0dfa6cd7b3d2c42d27d44dbdbba6d3799e31f428';
+
+/// See also [authService].
+@ProviderFor(authService)
+final authServiceProvider = AutoDisposeProvider<AuthService>.internal(
+  authService,
+  name: r'authServiceProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$authServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AuthServiceRef = AutoDisposeProviderRef<AuthService>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/auth/view/login_screen.dart
+++ b/lib/features/auth/view/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../view_model/login_view_model.dart';
+import '../provider/login_provider.dart';
 
 class LoginScreen extends ConsumerWidget {
   const LoginScreen({super.key});
@@ -15,7 +16,6 @@ class LoginScreen extends ConsumerWidget {
 
     final emailController = TextEditingController();
     final passwordController = TextEditingController();
-    final isPasswordVisible = StateProvider((ref) => false);
 
     return Scaffold(
       appBar: AppBar(title: const Text('ログイン')),
@@ -38,7 +38,7 @@ class LoginScreen extends ConsumerWidget {
             // パスワード
             Consumer(
               builder: (context, ref, _) {
-                final visible = ref.watch(isPasswordVisible);
+                final visible = ref.watch(isPasswordVisibleProvider);
                 return TextField(
                   controller: passwordController,
                   obscureText: !visible,
@@ -50,7 +50,7 @@ class LoginScreen extends ConsumerWidget {
                         visible ? Icons.visibility : Icons.visibility_off,
                       ),
                       onPressed: () {
-                        ref.read(isPasswordVisible.notifier).state = !visible;
+                        ref.read(isPasswordVisibleProvider.notifier).toggle();
                       },
                     ),
                   ),

--- a/lib/features/auth/view_model/login_view_model.dart
+++ b/lib/features/auth/view_model/login_view_model.dart
@@ -10,6 +10,7 @@ import '../service/auth_service.dart';
 
 part 'login_view_model.g.dart';
 
+@riverpod
 class LoginViewModel extends _$LoginViewModel {
   @override
   AsyncValue<void> build() {

--- a/lib/features/goals/view_model/goal_view_model.dart
+++ b/lib/features/goals/view_model/goal_view_model.dart
@@ -61,11 +61,16 @@ class GoalViewModel extends _$GoalViewModel {
   }
 }
 
-final userGoalsProvider = StreamProvider<List<Goal>>((ref) {
+@riverpod
+Stream<List<Goal>> userGoals(UserGoalsRef ref) {
   final user = ref.watch(userStateProvider);
   if (user == null) return const Stream.empty();
   return ref.watch(goalRepositoryProvider).streamGoalsForUser(user.uid);
-});
+}
 
-final goalListProvider = StateProvider<List<Goal>>((ref) => []);
+@riverpod
+class GoalList extends _$GoalList {
+  @override
+  List<Goal> build() => [];
+}
 

--- a/lib/features/goals/view_model/goal_view_model.g.dart
+++ b/lib/features/goals/view_model/goal_view_model.g.dart
@@ -6,7 +6,23 @@ part of 'goal_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goalViewModelHash() => r'3325ada36600b8d35193ee9832c3e2e0e0c19a32';
+String _$userGoalsHash() => r'a097003a32b77ad0b97d2ff7d3d5255b16abbf02';
+
+/// See also [userGoals].
+@ProviderFor(userGoals)
+final userGoalsProvider = AutoDisposeStreamProvider<List<Goal>>.internal(
+  userGoals,
+  name: r'userGoalsProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$userGoalsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef UserGoalsRef = AutoDisposeStreamProviderRef<List<Goal>>;
+String _$goalViewModelHash() => r'9725c34f3b199808ebbb10d3d91b718cdb144451';
 
 /// See also [GoalViewModel].
 @ProviderFor(GoalViewModel)
@@ -23,5 +39,20 @@ final goalViewModelProvider =
     );
 
 typedef _$GoalViewModel = AutoDisposeNotifier<AsyncValue<void>>;
+String _$goalListHash() => r'8f58b6b12b593db4524e1eb27386869f69675e40';
+
+/// See also [GoalList].
+@ProviderFor(GoalList)
+final goalListProvider =
+    AutoDisposeNotifierProvider<GoalList, List<Goal>>.internal(
+      GoalList.new,
+      name: r'goalListProvider',
+      debugGetCreateSourceHash:
+          const bool.fromEnvironment('dart.vm.product') ? null : _$goalListHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$GoalList = AutoDisposeNotifier<List<Goal>>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -500,10 +500,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -801,10 +801,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,14 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// Basic widget test to ensure the app builds without crashing.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:goal_tracker/app/router.dart';
-
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('App builds', (WidgetTester tester) async {
+    await tester.pumpWidget(ProviderScope(child: MyApp()));
+    await tester.pump(const Duration(seconds: 4)); // Allow splash timer to finish
+    expect(find.byType(MaterialApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- switch LoginViewModel to `@riverpod`
- add IsPasswordVisible provider and update LoginScreen to use it
- convert goal providers to annotation form
- generate provider code
- simplify widget test for router setup

## Testing
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684140cbca0c832384c6049aa0391f4d